### PR TITLE
Improvements to update_locales.yml

### DIFF
--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -6,10 +6,12 @@ on:
     branches: [ l10n_main ]
 
 jobs:
-  build:
+  update_locales:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: main
     # Create the mock file for the update_locales command to work, otherwise
     # we'll get an 'no such file' error
     - name: Create mock .env file
@@ -18,16 +20,18 @@ jobs:
     - name: Run update_locales command
       run: ./bw-dev update_locales
 
-    - name: Run update_locales and commit changes
+    - name: Create commit
       run: |
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
-        git fetch origin main:main
-        git switch main
-        git fetch origin l10n_main:l10n_main
-        ./bw-dev update_locales
         git add -A
         git commit -a -m "[GitHub Action] Update locales"
-        git push -u origin main
+
+    - name: Push to main branch
+      # we rebase it first, in case there was a push to main while running
+      # update_locales above
+      run: |
+        git pull --rebase
+        git push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding improvements from @dato
- rename job `build` -> `update_locales`; makes it easier to run locally with tools like "act"
- ensure checkout@v3 checks out `main` branch (which it doesn't by default since the workflow runs on l10n_main
- remove now unneeded switch to `main` by hand
- rebase commit before publishing, to minimize risk of failed push